### PR TITLE
Set SNI correctly in outgoing https requests

### DIFF
--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -45,7 +45,7 @@ void make_https_request(boost::asio::io_context& ioc,
     static ssl::context ctx{ssl::context::tlsv12_client};
 
     auto session = std::make_shared<HttpsClientSession>(
-        ioc, ctx, std::move(resolve_results), "service_node", req, std::move(cb),
+        ioc, ctx, std::move(resolve_results), "service-node", req, std::move(cb),
         sn_pubkey_b32z);
 
     session->start();

--- a/httpserver/https_client.h
+++ b/httpserver/https_client.h
@@ -68,6 +68,7 @@ class HttpsClientSession
     // Resolver and socket require an io_context
     HttpsClientSession(boost::asio::io_context& ioc, ssl::context& ssl_ctx,
                        tcp::resolver::results_type resolve_results,
+                       const char* host,
                        const std::shared_ptr<request_t>& req,
                        http_callback_t&& cb,
                        std::optional<std::string> sn_pubkey_b32z);


### PR DESCRIPTION
Tls handshake may fail if SNI is set incorrectly (or unset), which was the case for @nielsandriesse's server.