### PR TITLE
JSON/base64 opt-out for onion requests + oxend rpc proxy unwrapping

### DIFF
--- a/contrib/onion-request.cpp
+++ b/contrib/onion-request.cpp
@@ -243,7 +243,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     for (it++; it != keys.rend(); it++) {
         // Routing data for this hop:
         nlohmann::json routing{
-            {"destination", it->first.hex()}, // Next hop's ed25519 key
+            {"destination", std::prev(it)->first.hex()}, // Next hop's ed25519 key
             {"ephemeral_key", A.hex()}}; // The x25519 ephemeral_key here is the key for the *next* hop to use
 
         blob = encode_size(blob.size()) + blob + routing.dump();

--- a/contrib/onion-request.cpp
+++ b/contrib/onion-request.cpp
@@ -6,8 +6,8 @@
 // using static cpr from an oxen-core build, SS assets built in ../build, and system-installed
 // libsodium/libssl/nlohmann/oxenmq:
 //
-//     g++ -std=c++17 -O2 onion-request.cpp ../../oxen-core/build/external/libcpr.a \
-//          -loxenmq -lsodium -lcurl ../build/crypto/libcrypto.a -lcrypto
+//     g++ -std=c++17 -O2 onion-request.cpp -o onion-request ../../oxen-core/build/external/libcpr.a \
+//          ../build/crypto/libcrypto.a -loxenmq -lsodium -lcurl -lcrypto
 //
 
 #include "../crypto/include/channel_encryption.hpp"
@@ -26,32 +26,71 @@ extern "C" {
 
 using namespace oxen;
 
-int usage(const char* argv0) {
-    std::cerr << "Usage: " << argv0 << " [--mainnet] SNODE_PK [SNODE_PK ...] -- sends an onion request via the given path\n"
-       << "    SNODE_PK should be primary (legacy) pubkey(s)\n";
+int usage(std::string_view argv0, std::string_view err = "") {
+    if (!err.empty())
+        std::cerr << "\x1b[31;1mError: " << err << "\x1b[0m\n\n";
+    std::cerr << "Usage: " << argv0 << R"( [--mainnet] SNODE_PK [SNODE_PK ...] PAYLOAD CONTROL
+
+Sends an onion request via the given path
+
+SNODE_PK should be primary (legacy) pubkey(s)
+PAYLOAD/CONTROL are values to pass to the request and should be:
+
+Onion requests for SS and oxend:
+
+    Pass '{"headers":[]}' for CONTROL
+
+    PAYLOAD should be the JSON data; for example for an oxend request:
+
+        {"method": "oxend_request", "params": {"endpoint": "get_service_nodes", "params": {"limit": 5}}}
+
+    and for a swarm member lookup:
+
+        {"method": "get_snodes_for_pubkey", {"params": {"pubKey": user_pubkey}}}
+
+Proxy requests should have an whatever data is to be posted in the PAYLOAD string and CONTROL set to
+the connection details such as:
+
+        {"host": "jagerman.com", "target": "/oxen/lsrpc"}
+
+)";
     return 1;
 }
 
 const oxenmq::address TESTNET_OMQ{"tcp://public.loki.foundation:9999"};
 const oxenmq::address MAINNET_OMQ{"tcp://public.loki.foundation:22029"};
 
-void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_pubkey, x25519_pubkey>> keys, bool mainnet);
+void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_pubkey, x25519_pubkey>> keys,
+        bool mainnet, std::string_view payload, std::string_view control);
 
 int main(int argc, char** argv) {
     std::vector<std::string_view> pubkeys_hex;
     std::vector<legacy_pubkey> pubkeys;
     auto omq_addr = TESTNET_OMQ;
+    std::string payload, control;
     for (int i = 1; i < argc; i++) {
-        if (argv[i] == "--mainnet"sv) {
+        std::string_view arg{argv[i]};
+        if (arg == "--mainnet"sv) {
             omq_addr = MAINNET_OMQ;
             continue;
         }
-        auto pk = pubkeys_hex.emplace_back(argv[i]);
-        if (pk.size() != 64 || !oxenmq::is_hex(pk)) {
-            std::cerr << "Invalid pubkey '" << pk << "'\n";
-            return usage(argv[0]);
+        if (arg == "--testnet"sv)
+            continue;
+
+        bool hex = arg.size() > 0 && oxenmq::is_hex(arg);
+        if (i >= argc - 2) {
+            if (hex)
+                return usage(argv[0], "Missing PAYLOAD and CONTROL values");
+
+            // Could parse control to make sure it's valid json here, but it can be useful to
+            // deliberate send invalid json for testing purposes to see how the remote handles it.
+            (i == argc - 2 ? payload : control) = arg;
+        } else {
+            if (!(hex && arg.size() == 64))
+                return usage(argv[0], "Invalid pubkey '" + std::string{arg} + "'");
+            pubkeys_hex.push_back(arg);
+            pubkeys.push_back(legacy_pubkey::from_hex(arg));
         }
-        pubkeys.push_back(legacy_pubkey::from_hex(pk));
     }
     if (pubkeys.empty()) return usage(argv[0]);
 
@@ -114,12 +153,13 @@ int main(int argc, char** argv) {
                 std::cerr << pk << " is not an active SN\n";
         }
         if (chain.size() != pubkeys.size()) throw std::runtime_error{"Missing x25519 pubkeys"};
-        if (chain.size() < 2) throw std::runtime_error{"Need at least two pubkeys"};
+        if (chain.empty()) throw std::runtime_error{"Need at least one SN pubkey"};
 
         if (first_ip.empty() || !first_port)
             throw std::runtime_error{"Missing IP/port of first hop"};
 
-        onion_request(first_ip, first_port, std::move(chain), omq_addr == MAINNET_OMQ);
+        onion_request(first_ip, first_port, std::move(chain), omq_addr == MAINNET_OMQ,
+                payload, control);
 
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what();
@@ -138,7 +178,8 @@ std::string encode_size(uint32_t s) {
     return str;
 }
 
-void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_pubkey, x25519_pubkey>> keys, bool mainnet) {
+void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_pubkey, x25519_pubkey>> keys, bool mainnet,
+        std::string_view payload, std::string_view control) {
     std::string_view user_pubkey = "05fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
     if (!mainnet) user_pubkey.remove_prefix(2);
 
@@ -188,30 +229,13 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     {
         crypto_box_keypair(A.data(), a.data());
         oxen::ChannelEncryption e{a};
-#if 1
-        // get_snodes_for_pubkey request returns some json:
-        auto payload = nlohmann::json{
-            {"method", "get_snodes_for_pubkey"},
-            {"params", {
-                {"pubKey", user_pubkey},
-                {"foobar", true},
-            }}
-        }.dump();
 
-        auto control = nlohmann::json{
-                {"headers", std::array<int, 0>{}}}.dump();
-
-#else
-        // A proxy request to a target (which must start '/oxen/' or '/loki' and end '/lsrpc'):
-        auto payload = ""s;
-        auto control = nlohmann::json{
-                {"host", "jagerman.com"},
-                {"target", "/oxen/lsrpc"}}.dump();
-#endif
-
-        auto data = encode_size(payload.size()) + payload + control;
+        auto data = encode_size(payload.size());
+        data += payload;
+        data += control;
 
         blob = e.encrypt(EncryptType::aes_gcm, data, keys.back().second);
+        // Save these because we need them again to decrypt the final response:
         final_seckey = a;
         final_pubkey = A;
     }
@@ -220,7 +244,6 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
         // Routing data for this hop:
         nlohmann::json routing{
             {"destination", it->first.hex()}, // Next hop's ed25519 key
-            {"foobar", "fedcba"},
             {"ephemeral_key", A.hex()}}; // The x25519 ephemeral_key here is the key for the *next* hop to use
 
         blob = encode_size(blob.size()) + blob + routing.dump();
@@ -230,37 +253,54 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
         oxen::ChannelEncryption e{a};
 
         blob = e.encrypt(EncryptType::aes_gcm, blob, it->second);
-
-        if (std::next(it) == keys.rend()) {
-            // This is the first hop, so have to add one more layer to tell the first hop how to
-            // decrypt the initial payload:
-            blob = encode_size(blob.size()) + blob +
-                nlohmann::json{{"ephemeral_key", A.hex()}}.dump();
-        }
     }
 
+    // The data going to the first hop needs to be wrapped in one more layer to tell the first hop
+    // how to decrypt the initial payload:
+    blob = encode_size(blob.size()) + blob + nlohmann::json{{"ephemeral_key", A.hex()}}.dump();
+
     cpr::Url target{"https://" + ip + ":" + std::to_string(port) + "/onion_req/v2"};
-    std::cout << "Posting to " << target.str() << " for entry node\n";
+    std::cerr << "Posting to " << target.str() << " for entry node\n";
     auto res = cpr::Post(target,
             cpr::Body{blob},
             cpr::VerifySsl{false});
 
-    std::cout << "Got " << res.status_line << " response\n";
-    if (!res.raw_header.empty())
-        std::cout << "Headers:\n" << res.raw_header << "\n\n";
+    std::cerr << "Got " << res.status_line << " response\n";
+    for (auto& [k, v] : res.header)
+        std::cerr << "- " << k << ": " << v << "\n";
 
-    if (!oxenmq::is_base64(res.text)) {
-        std::cout << "Body (" << res.text.size() << " bytes):\n" << res.text << "\n";
-    } else {
-        auto body = oxenmq::from_base64(res.text);
-        std::cout << "Body is " << res.text.size() << " base64 bytes for " << body.size() << " bytes of data\n";
-        oxen::ChannelEncryption d{final_seckey};
-        try {
-            body = d.decrypt(EncryptType::aes_gcm, body, keys.back().second);
-
-            std::cout << "Body decrypted to " << body.size() << " bytes:\n" << body << "\n";
-        } catch (const std::exception& e) {
-            std::cerr << "Decryption failed: " << e.what() << "\n";
-        }
+    if (res.text.empty()) {
+        std::cerr << "Request returned empty body\n";
+        return;
     }
+
+    // Nothing in the response tells us how it is encoded so we have to guess; the client normally
+    // *does* know because it specifies `"base64": false` if it wants binary, but I don't want to
+    // parse and guess what we should do, so we'll just guess.
+    oxen::ChannelEncryption d{final_seckey};
+    bool decrypted = false;
+    auto body = std::move(res.text);
+    auto orig_size = body.size();
+    try { body = d.decrypt(EncryptType::aes_gcm, body, keys.back().second); decrypted = true; }
+    catch (...) {}
+
+    if (decrypted) {
+        std::cerr << "Body is " << orig_size << " encrypted bytes, decrypted to " << body.size() << " bytes:\n";
+    } else if (oxenmq::is_base64(body)) {
+        body = oxenmq::from_base64(body);
+        std::cerr << "Body was " << orig_size << " base64 bytes; decoded to " << body.size() << " bytes";
+        try { body = d.decrypt(EncryptType::aes_gcm, body, keys.back().second); decrypted = true; }
+        catch (...) {}
+        if (decrypted)
+            std::cerr << "; decrypted to " << body.size() << " bytes:\n";
+        else
+            std::cerr << "; not encrypted (or decryption failed)\n";
+    } else {
+        std::cerr << "Body is " << body.size() << " bytes (not base64-encoded, not encrypted [or decryption failed])\n";
+    }
+    std::cerr << std::flush;
+
+    std::cout << body;
+    if (!body.empty() && body.back() != '\n')
+        std::cout << '\n';
 }

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -668,7 +668,7 @@ void connection_t::process_request() {
 
             try {
                 process_client_req_rate_limited();
-            } catch (std::exception& e) {
+            } catch (const std::exception& e) {
                 this->body_stream_ << fmt::format(
                     "Exception caught while processing client request: {}",
                     e.what());

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -88,8 +88,7 @@ void make_http_request(boost::asio::io_context& ioc, const std::string& address,
         if (ec) {
             OXEN_LOG(error, "DNS resolution error for {}: {}", address,
                      ec.message());
-            cb({SNodeError::ERROR_OTHER});
-            return;
+            return cb({SNodeError::ERROR_OTHER});
         }
 
         tcp::endpoint endpoint;
@@ -111,8 +110,7 @@ void make_http_request(boost::asio::io_context& ioc, const std::string& address,
 
         if (!resolved) {
             OXEN_LOG(error, "[HTTP] DNS resolution error for {}", address);
-            cb({SNodeError::ERROR_OTHER});
-            return;
+            return cb({SNodeError::ERROR_OTHER});
         }
 
         endpoint.port(port);

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -501,7 +501,7 @@ void connection_t::process_onion_req_v2() {
     delay_response_ = true;
 
     auto on_response = [wself = weak_from_this()](oxen::Response res) {
-        OXEN_LOG(debug, "Got an onion response as guard node");
+        OXEN_LOG(debug, "Got an onion response as edge node");
 
         auto self = wself.lock();
         if (!self) {

--- a/httpserver/onion_processing.cpp
+++ b/httpserver/onion_processing.cpp
@@ -56,7 +56,7 @@ auto process_inner_request(std::string plaintext) -> ParsedInfo {
                 inner_json.at("destination").get_ref<const std::string&>());
             eph_key = inner_json.at("ephemeral_key").get<std::string>();
         }
-    } catch (std::exception& e) {
+    } catch (const std::exception& e) {
         OXEN_LOG(debug, "Error parsing inner JSON in onion request: {}",
                  e.what());
         ret = ProcessCiphertextError::INVALID_JSON;

--- a/httpserver/onion_processing.cpp
+++ b/httpserver/onion_processing.cpp
@@ -84,10 +84,6 @@ process_ciphertext_v2(const ChannelEncryption& decryptor,
     return process_inner_request(std::move(*plaintext));
 }
 
-static auto gateway_timeout() -> oxen::Response {
-    return oxen::Response{Status::GATEWAY_TIMEOUT, "Request time out"};
-}
-
 static auto make_status(std::string_view status) -> oxen::Status {
 
     int code;
@@ -137,8 +133,7 @@ static void relay_to_node(const ServiceNode& service_node,
     if (!dest_node) {
         auto msg = fmt::format("Next node not found: {}", dest);
         OXEN_LOG(warn, "{}", msg);
-        cb({Status::BAD_GATEWAY, std::move(msg)});
-        return;
+        return cb({Status::BAD_GATEWAY, std::move(msg)});
     }
 
 
@@ -148,17 +143,15 @@ static void relay_to_node(const ServiceNode& service_node,
 
         if (!success) {
             OXEN_LOG(debug, "[Onion request] Request time out");
-            cb(gateway_timeout());
-            return;
+            return cb({Status::GATEWAY_TIMEOUT, "Request time out"});
         }
 
         // We only expect a two-part message
         if (data.size() != 2) {
             OXEN_LOG(debug, "[Onion request] Incorrect number of messages: {}",
                      data.size());
-            cb(oxen::Response{Status::INTERNAL_SERVER_ERROR,
-                              "Incorrect number of messages from gateway"});
-            return;
+            return cb({Status::INTERNAL_SERVER_ERROR,
+                    "Incorrect number of messages from gateway"});
         }
 
         /// We use http status codes (for now)
@@ -195,17 +188,14 @@ void RequestHandler::process_onion_req(std::string_view ciphertext,
         auto msg =
             fmt::format("Snode not ready: {}",
                         service_node_.own_address().pubkey_ed25519);
-        cb(oxen::Response{Status::SERVICE_UNAVAILABLE, std::move(msg)});
-        return;
+        return cb({Status::SERVICE_UNAVAILABLE, std::move(msg)});
     }
 
     OXEN_LOG(debug, "process_onion_req, v2: {}", v2);
 
     if (!v2) {
         OXEN_LOG(warn, "onion requests v1 are no longer supported");
-        cb(oxen::Response{Status::BAD_REQUEST,
-                          "onion requests v1 not supported"});
-        return;
+        return cb({Status::BAD_REQUEST, "onion requests v1 not supported"});
     }
 
     ParsedInfo res = process_ciphertext_v2(channel_cipher_, ciphertext, ephem_key);
@@ -214,7 +204,7 @@ void RequestHandler::process_onion_req(std::string_view ciphertext,
 
         OXEN_LOG(debug, "We are the final destination in the onion request!");
 
-        this->process_onion_exit(
+        return process_onion_exit(
             ephem_key, info->body,
             [this, ephem_key, cb = std::move(cb), json = info->json, b64 = info->base64]
             (oxen::Response res) {
@@ -223,7 +213,7 @@ void RequestHandler::process_onion_req(std::string_view ciphertext,
 
     } else if (const auto info = std::get_if<RelayToNodeInfo>(&res)) {
 
-        relay_to_node(this->service_node_, *info, std::move(cb), v2);
+        return relay_to_node(this->service_node_, *info, std::move(cb), v2);
 
     } else if (const auto info = std::get_if<RelayToServerInfo>(&res)) {
         OXEN_LOG(debug, "We are to forward the request to url: {}{}",
@@ -233,27 +223,23 @@ void RequestHandler::process_onion_req(std::string_view ciphertext,
 
         // Forward the request to url but only if it ends in `/lsrpc`
         if (is_server_url_allowed(target)) {
-            this->process_onion_to_url(info->protocol, info->host, info->port,
+            return process_onion_to_url(info->protocol, info->host, info->port,
                                        target, info->payload, std::move(cb));
 
         } else {
-            cb(wrap_proxy_response({Status::BAD_REQUEST, "Invalid url"},
+            return cb(wrap_proxy_response({Status::BAD_REQUEST, "Invalid url"},
                     ephem_key, EncryptType::aes_gcm));
         }
 
     } else if (const auto error = std::get_if<ProcessCiphertextError>(&res)) {
         switch (*error) {
-        case ProcessCiphertextError::INVALID_CIPHERTEXT: {
+        case ProcessCiphertextError::INVALID_CIPHERTEXT:
             // Should this error be propagated back to the client? (No, if we
             // couldn't decrypt, we probably won't be able to encrypt either.)
-            cb({Status::BAD_REQUEST, "Invalid ciphertext"});
-            break;
-        }
-        case ProcessCiphertextError::INVALID_JSON: {
-            cb(wrap_proxy_response({Status::BAD_REQUEST, "Invalid json"},
+            return cb({Status::BAD_REQUEST, "Invalid ciphertext"});
+        case ProcessCiphertextError::INVALID_JSON:
+            return cb(wrap_proxy_response({Status::BAD_REQUEST, "Invalid json"},
                     ephem_key, EncryptType::aes_gcm));
-            break;
-        }
         }
     } else {
         OXEN_LOG(error, "UNKNOWN VARIANT");

--- a/httpserver/onion_processing.h
+++ b/httpserver/onion_processing.h
@@ -44,7 +44,24 @@ bool operator==(const RelayToServerInfo& lhs, const RelayToServerInfo& rhs);
 
 /// We are the final destination for this request
 struct FinalDestinationInfo {
+    // Request body
     std::string body;
+
+    // If true, and the response has a content type indicating json, then embed the "body" value as
+    // a direct json value rather than encapsulating it as a json string.  For example, when false
+    // (the default for backwards compatibility) a json response of {"hi": "123"} would get returned
+    // as:
+    //
+    //     {"body":"{\"hi\":\"123\"},"status":200}  // json=false
+    //     {"body":{"hi":"123"},"status":200}       // json=true
+    //
+    // Note that this json isn't actually parsed and so this can result in invalid json if the
+    // supposed-json inner value is not actually json.
+    bool json = false;
+
+    // If true (which is the default for backwards compatibility) then encode the encrypted response
+    // as base64; if false return the encrypted response as-is.
+    bool base64 = true;
 };
 
 std::ostream& operator<<(std::ostream& os, const FinalDestinationInfo& p);

--- a/httpserver/oxend_rpc.cpp
+++ b/httpserver/oxend_rpc.cpp
@@ -62,7 +62,7 @@ oxend_seckeys get_sn_privkeys(std::string_view oxend_rpc_address) {
 
         try {
             return fut.get();
-        } catch (std::exception& e) {
+        } catch (const std::exception& e) {
             OXEN_LOG(critical, "Error retrieving private keys from oxend: {}; retrying", e.what());
         }
     }

--- a/httpserver/request_handler.cpp
+++ b/httpserver/request_handler.cpp
@@ -533,7 +533,7 @@ void RequestHandler::process_proxy_exit(
             }
         }
 
-    } catch (std::exception& e) {
+    } catch (const std::exception& e) {
         auto msg = fmt::format("JSON parsing error: {}", e.what());
         OXEN_LOG(debug, "[{}] {}", idx, msg);
         auto res = Response{Status::BAD_REQUEST, msg};

--- a/httpserver/request_handler.cpp
+++ b/httpserver/request_handler.cpp
@@ -357,7 +357,7 @@ void RequestHandler::process_client_req(
     const json body = json::parse(req_json, nullptr, false);
     if (body.is_discarded()) {
         OXEN_LOG(debug, "Bad client request: invalid json");
-        cb(Response{Status::BAD_REQUEST, "invalid json\n"});
+        return cb(Response{Status::BAD_REQUEST, "invalid json\n"});
     }
 
     if (OXEN_LOG_ENABLED(trace))
@@ -366,7 +366,7 @@ void RequestHandler::process_client_req(
     const auto method_it = body.find("method");
     if (method_it == body.end() || !method_it->is_string()) {
         OXEN_LOG(debug, "Bad client request: no method field");
-        cb(Response{Status::BAD_REQUEST, "invalid json: no `method` field\n"});
+        return cb(Response{Status::BAD_REQUEST, "invalid json: no `method` field\n"});
     }
 
     const auto& method_name = method_it->get_ref<const std::string&>();
@@ -376,7 +376,7 @@ void RequestHandler::process_client_req(
     const auto params_it = body.find("params");
     if (params_it == body.end() || !params_it->is_object()) {
         OXEN_LOG(debug, "Bad client request: no params field");
-        cb(Response{Status::BAD_REQUEST, "invalid json: no `params` field\n"});
+        return cb(Response{Status::BAD_REQUEST, "invalid json: no `params` field\n"});
     }
 
     if (method_name == "store") {

--- a/httpserver/request_handler.h
+++ b/httpserver/request_handler.h
@@ -121,6 +121,15 @@ class RequestHandler {
     void process_client_req(const std::string& req_json,
                             std::function<void(oxen::Response)> cb);
 
+    // Forwards a request to oxend RPC. `params` should contain:
+    // - endpoint -- the name of the rpc endpoint; currently allowed are `ons_resolve` and
+    // `get_service_nodes`.
+    // - params -- optional dict of parameters to pass through to oxend as part of the request
+    //
+    // See oxen-core/rpc/core_rpc_server_command_defs.h for parameters to these endpoints.
+    //
+    // Returns (via the response callback) the oxend JSON object on success; on failure returns
+    // a failure response with a body of the error string.
     void process_oxend_request(const nlohmann::json& params,
                                std::function<void(oxen::Response)> cb);
 

--- a/httpserver/request_handler.h
+++ b/httpserver/request_handler.h
@@ -83,7 +83,7 @@ class RequestHandler {
     const ChannelEncryption& channel_cipher_;
 
     // Wrap response `res` to an intermediate node
-    Response wrap_proxy_response(const Response& res,
+    Response wrap_proxy_response(Response res,
                                  const x25519_pubkey& client_key,
                                  EncryptType enc_type,
                                  bool json = false,

--- a/httpserver/request_handler.h
+++ b/httpserver/request_handler.h
@@ -85,7 +85,9 @@ class RequestHandler {
     // Wrap response `res` to an intermediate node
     Response wrap_proxy_response(const Response& res,
                                  const x25519_pubkey& client_key,
-                                 EncryptType enc_type) const;
+                                 EncryptType enc_type,
+                                 bool json = false,
+                                 bool base64 = true) const;
 
     // Return the correct swarm for `pubKey`
     Response handle_wrong_swarm(const user_pubkey_t& pubKey);


### PR DESCRIPTION
Allows a client to opt-out of json double-encoding and base64 encoding of encrypted onion request data.

See commit descriptions for details.

TL;DR:
- add `"json":true, "base64":false` into the onion control section (where "headers" is) to get rid of base64 encoding + double json
- oxend requests embed json objects instead of json string, renames "oxend_params" to "params", and makes it optional.