### PR TITLE
SS-to-SS onion req internal protocol refactor, max hops, xchacha20 encryption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 cmake_minimum_required(VERSION 3.10)
 
 project(storage_server
-    VERSION 2.0.9
+    VERSION 2.1.0
     LANGUAGES CXX C)
 
 option(INTEGRATION_TEST "build for integration test" OFF)

--- a/contrib/onion-request.cpp
+++ b/contrib/onion-request.cpp
@@ -7,7 +7,7 @@
 // libsodium/libssl/nlohmann/oxenmq:
 //
 //     g++ -std=c++17 -O2 onion-request.cpp -o onion-request ../../oxen-core/build/external/libcpr.a \
-//          ../build/crypto/libcrypto.a -loxenmq -lsodium -lcurl -lcrypto
+//          -I../../oxen-core/external/cpr/include ../build/crypto/libcrypto.a -loxenmq -lsodium -lcurl -lcrypto
 //
 
 #include "../crypto/include/channel_encryption.hpp"
@@ -251,7 +251,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     auto it = keys.rbegin();
     {
         crypto_box_keypair(A.data(), a.data());
-        oxen::ChannelEncryption e{a, A};
+        oxen::ChannelEncryption e{a, A, false};
 
         auto data = encode_size(payload.size());
         data += payload;
@@ -279,7 +279,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
 
         // Generate eph key for *this* request and encrypt it:
         crypto_box_keypair(A.data(), a.data());
-        oxen::ChannelEncryption e{a, A};
+        oxen::ChannelEncryption e{a, A, false};
         last_etype = enc_type.value_or(random_etype());
 
 #ifndef NDEBUG
@@ -314,7 +314,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     // Nothing in the response tells us how it is encoded so we have to guess; the client normally
     // *does* know because it specifies `"base64": false` if it wants binary, but I don't want to
     // parse and guess what we should do, so we'll just guess.
-    oxen::ChannelEncryption d{final_seckey, final_pubkey};
+    oxen::ChannelEncryption d{final_seckey, final_pubkey, false};
     bool decrypted = false;
     auto body = std::move(res.text);
     auto orig_size = body.size();

--- a/crypto/include/channel_encryption.hpp
+++ b/crypto/include/channel_encryption.hpp
@@ -10,14 +10,17 @@ namespace oxen {
 enum class EncryptType {
     aes_cbc,
     aes_gcm,
+    xchacha20,
 };
 
 // Takes the encryption type as a string, returns the EncryptType value (or throws if invalid).
-// Supported values: aes-gcm, aes-cbc.  gcm and cbc are accepted as aliases for the aes- version.
+// Supported values: aes-gcm, aes-cbc, xchacha20.  gcm and cbc are accepted as aliases for the aes-
+// version.
 EncryptType parse_enc_type(std::string_view enc_type);
 
 inline constexpr std::string_view to_string(EncryptType type) {
     switch (type) {
+        case EncryptType::xchacha20: return "xchacha20"sv;
         case EncryptType::aes_gcm: return "aes-gcm"sv;
         case EncryptType::aes_cbc: return "aes-cbc"sv;
     }
@@ -27,24 +30,30 @@ inline constexpr std::string_view to_string(EncryptType type) {
 // Encryption/decription class for encryption/decrypting outgoing/incoming messages.
 class ChannelEncryption {
   public:
-    ChannelEncryption(x25519_seckey private_key)
-        : private_key_{std::move(private_key)} {}
+    ChannelEncryption(x25519_seckey private_key, x25519_pubkey public_key)
+        : private_key_{std::move(private_key)}, public_key_{std::move(public_key)} {}
 
     std::string encrypt(EncryptType type, std::string_view plaintext, const x25519_pubkey& pubkey) const;
     std::string decrypt(EncryptType type, std::string_view ciphertext, const x25519_pubkey& pubkey) const;
 
     // AES-CBC encryption.
     std::string encrypt_cbc(std::string_view plainText, const x25519_pubkey& pubKey) const;
+    std::string decrypt_cbc(std::string_view cipherText, const x25519_pubkey& pubKey) const;
 
     // AES-GCM encryption.
     std::string encrypt_gcm(std::string_view plainText, const x25519_pubkey& pubKey) const;
-
-    std::string decrypt_cbc(std::string_view cipherText, const x25519_pubkey& pubKey) const;
-
     std::string decrypt_gcm(std::string_view cipherText, const x25519_pubkey& pubKey) const;
+
+    // xchacha20-poly1305 encryption; for a message sent from Alice to Bob we use a shared key of a
+    // Blake2B 32-byte (i.e.  crypto_aead_xchacha20poly1305_ietf_KEYBYTES) hash of H(aB || A || B),
+    // which Bob can compute when receiving as H(bA || A || B).  The returned value always has the
+    // crypto_aead_xchacha20poly1305_ietf_NPUBBYTES nonce prepended to the beginning.
+    std::string encrypt_xchacha20(std::string_view plaintext, const x25519_pubkey& pubKey) const;
+    std::string decrypt_xchacha20(std::string_view ciphertext, const x25519_pubkey& pubKey) const;
 
   private:
     const x25519_seckey private_key_;
+    const x25519_pubkey public_key_;
 };
 
 }

--- a/crypto/include/channel_encryption.hpp
+++ b/crypto/include/channel_encryption.hpp
@@ -30,9 +30,12 @@ inline constexpr std::string_view to_string(EncryptType type) {
 // Encryption/decription class for encryption/decrypting outgoing/incoming messages.
 class ChannelEncryption {
   public:
-    ChannelEncryption(x25519_seckey private_key, x25519_pubkey public_key)
-        : private_key_{std::move(private_key)}, public_key_{std::move(public_key)} {}
+    ChannelEncryption(x25519_seckey private_key, x25519_pubkey public_key, bool server = true)
+        : private_key_{std::move(private_key)}, public_key_{std::move(public_key)}, server_{server} {}
 
+    // Encrypts `plaintext` message using encryption `type`. `pubkey` is the recipients public key.
+    // `reply` should be false for a client-to-snode message, and true on a returning
+    // snode-to-client message.
     std::string encrypt(EncryptType type, std::string_view plaintext, const x25519_pubkey& pubkey) const;
     std::string decrypt(EncryptType type, std::string_view ciphertext, const x25519_pubkey& pubkey) const;
 
@@ -44,16 +47,21 @@ class ChannelEncryption {
     std::string encrypt_gcm(std::string_view plainText, const x25519_pubkey& pubKey) const;
     std::string decrypt_gcm(std::string_view cipherText, const x25519_pubkey& pubKey) const;
 
-    // xchacha20-poly1305 encryption; for a message sent from Alice to Bob we use a shared key of a
-    // Blake2B 32-byte (i.e.  crypto_aead_xchacha20poly1305_ietf_KEYBYTES) hash of H(aB || A || B),
-    // which Bob can compute when receiving as H(bA || A || B).  The returned value always has the
-    // crypto_aead_xchacha20poly1305_ietf_NPUBBYTES nonce prepended to the beginning.
+    // xchacha20-poly1305 encryption; for a message sent from client Alice to server Bob we use a
+    // shared key of a Blake2B 32-byte (i.e. crypto_aead_xchacha20poly1305_ietf_KEYBYTES) hash of
+    // H(aB || A || B), which Bob can compute when receiving as H(bA || A || B).  The returned value
+    // always has the crypto_aead_xchacha20poly1305_ietf_NPUBBYTES nonce prepended to the beginning.
+    //
+    // When Bob (the server) encrypts a method for Alice (the client), he uses shared key
+    // H(bA || A || B) (note that this is *different* that what would result if Bob was a client
+    // sending to Alice the client).
     std::string encrypt_xchacha20(std::string_view plaintext, const x25519_pubkey& pubKey) const;
     std::string decrypt_xchacha20(std::string_view ciphertext, const x25519_pubkey& pubKey) const;
 
   private:
     const x25519_seckey private_key_;
     const x25519_pubkey public_key_;
+    bool server_; // True if we are the server (i.e. the snode).
 };
 
 }

--- a/crypto/src/channel_encryption.cpp
+++ b/crypto/src/channel_encryption.cpp
@@ -28,12 +28,6 @@ calculate_shared_secret(const x25519_seckey& seckey,
     return secret;
 }
 
-EncryptType parse_enc_type(std::string_view enc_type) {
-    if (enc_type == "aes-gcm" || enc_type == "gcm") return EncryptType::aes_gcm;
-    if (enc_type == "aes-cbc" || enc_type == "cbc") return EncryptType::aes_cbc;
-    throw std::runtime_error{"Invalid encryption type " + std::string{enc_type}};
-}
-
 std::basic_string_view<unsigned char> to_uchar(std::string_view sv) {
     return {reinterpret_cast<const unsigned char*>(sv.data()), sv.size()};
 }
@@ -66,6 +60,12 @@ struct aes256_evp_deleter {
 using aes256cbc_ctx_ptr = std::unique_ptr<EVP_CIPHER_CTX, aes256_evp_deleter>;
 
 
+}
+
+EncryptType parse_enc_type(std::string_view enc_type) {
+    if (enc_type == "aes-gcm" || enc_type == "gcm") return EncryptType::aes_gcm;
+    if (enc_type == "aes-cbc" || enc_type == "cbc") return EncryptType::aes_cbc;
+    throw std::runtime_error{"Invalid encryption type " + std::string{enc_type}};
 }
 
 std::string ChannelEncryption::encrypt(EncryptType type, std::string_view plaintext, const x25519_pubkey& pubkey) const {

--- a/crypto/src/channel_encryption.cpp
+++ b/crypto/src/channel_encryption.cpp
@@ -63,6 +63,7 @@ using aes256cbc_ctx_ptr = std::unique_ptr<EVP_CIPHER_CTX, aes256_evp_deleter>;
 }
 
 EncryptType parse_enc_type(std::string_view enc_type) {
+    if (enc_type == "xchacha20" || enc_type == "xchacha20-poly1305") return EncryptType::xchacha20;
     if (enc_type == "aes-gcm" || enc_type == "gcm") return EncryptType::aes_gcm;
     if (enc_type == "aes-cbc" || enc_type == "cbc") return EncryptType::aes_cbc;
     throw std::runtime_error{"Invalid encryption type " + std::string{enc_type}};
@@ -70,6 +71,7 @@ EncryptType parse_enc_type(std::string_view enc_type) {
 
 std::string ChannelEncryption::encrypt(EncryptType type, std::string_view plaintext, const x25519_pubkey& pubkey) const {
     switch (type) {
+        case EncryptType::xchacha20: return encrypt_xchacha20(plaintext, pubkey);
         case EncryptType::aes_gcm: return encrypt_gcm(plaintext, pubkey);
         case EncryptType::aes_cbc: return encrypt_cbc(plaintext, pubkey);
     }
@@ -78,6 +80,7 @@ std::string ChannelEncryption::encrypt(EncryptType type, std::string_view plaint
 
 std::string ChannelEncryption::decrypt(EncryptType type, std::string_view ciphertext, const x25519_pubkey& pubkey) const {
     switch (type) {
+        case EncryptType::xchacha20: return decrypt_xchacha20(ciphertext, pubkey);
         case EncryptType::aes_gcm: return decrypt_gcm(ciphertext, pubkey);
         case EncryptType::aes_cbc: return decrypt_cbc(ciphertext, pubkey);
     }
@@ -236,6 +239,81 @@ std::string ChannelEncryption::decrypt_cbc(
     output.resize(reinterpret_cast<char*>(o) - output.data());
 
     return output;
+}
+
+static std::array<unsigned char, crypto_aead_xchacha20poly1305_ietf_KEYBYTES>
+xchacha20_shared_key(
+        const x25519_pubkey& local_pub,
+        const x25519_seckey& local_sec,
+        const x25519_pubkey& remote_pub,
+        bool sending) {
+    std::array<unsigned char, crypto_aead_xchacha20poly1305_ietf_KEYBYTES> key;
+    static_assert(crypto_aead_xchacha20poly1305_ietf_KEYBYTES >= crypto_scalarmult_BYTES);
+    if (0 != crypto_scalarmult(key.data(), local_sec.data(), remote_pub.data())) // Use key as tmp storage for aB
+        throw std::runtime_error{"Failed to compute shared key for xchacha20"};
+    crypto_generichash_state h;
+    crypto_generichash_init(&h, nullptr, 0, key.size());
+    crypto_generichash_update(&h, key.data(), crypto_scalarmult_BYTES);
+    crypto_generichash_update(&h, (sending ? local_pub : remote_pub).data(), local_pub.size());
+    crypto_generichash_update(&h, (sending ? remote_pub : local_pub).data(), local_pub.size());
+    crypto_generichash_final(&h, key.data(), key.size());
+    return key;
+}
+
+std::string ChannelEncryption::encrypt_xchacha20(std::string_view plaintext_, const x25519_pubkey& pubKey) const {
+    auto plaintext = to_uchar(plaintext_);
+
+    std::string ciphertext;
+    ciphertext.resize(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + plaintext.size()
+            + crypto_aead_xchacha20poly1305_ietf_ABYTES);
+
+    const auto key = xchacha20_shared_key(public_key_, private_key_, pubKey, true);
+
+    // Generate random nonce, and stash it at the beginning of ciphertext:
+    randombytes_buf(ciphertext.data(), crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+
+    auto* c = reinterpret_cast<unsigned char*>(ciphertext.data())
+        + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+    unsigned long long clen;
+
+    crypto_aead_xchacha20poly1305_ietf_encrypt(
+            c, &clen,
+            plaintext.data(), plaintext.size(),
+            nullptr, 0, // additional data
+            nullptr, // nsec (always unused)
+            reinterpret_cast<const unsigned char*>(ciphertext.data()),
+            key.data());
+    assert(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + clen <= ciphertext.size());
+    ciphertext.resize(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + clen);
+    return ciphertext;
+}
+
+std::string ChannelEncryption::decrypt_xchacha20(std::string_view ciphertext_, const x25519_pubkey& pubKey) const {
+    auto ciphertext = to_uchar(ciphertext_);
+
+    // Extract nonce from the beginning of the ciphertext:
+    auto nonce = ciphertext.substr(0, crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+    ciphertext.remove_prefix(nonce.size());
+    if (ciphertext.size() < crypto_aead_xchacha20poly1305_ietf_ABYTES)
+        throw std::runtime_error{"Invalid ciphertext: too short"};
+
+    const auto key = xchacha20_shared_key(public_key_, private_key_, pubKey, false);
+
+    std::string plaintext;
+    plaintext.resize(ciphertext.size() - crypto_aead_xchacha20poly1305_ietf_ABYTES);
+    auto* m = reinterpret_cast<unsigned char*>(plaintext.data());
+    unsigned long long mlen;
+    if (0 != crypto_aead_xchacha20poly1305_ietf_decrypt(
+            m, &mlen,
+            nullptr, // nsec (always unused)
+            ciphertext.data(), ciphertext.size(),
+            nullptr, 0, // additional data
+            nonce.data(),
+            key.data()))
+        throw std::runtime_error{"Could not decrypt (XChaCha20-Poly1305)"};
+    assert(mlen <= plaintext.size());
+    plaintext.resize(mlen);
+    return plaintext;
 }
 
 }

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -523,7 +523,7 @@ void connection_t::process_onion_req_v2() {
 
         service_node_.record_onion_request();
         request_handler_.process_onion_req(std::move(ciphertext), ephem_key,
-                                           on_response, true);
+                                           on_response);
 
     } catch (const std::exception& e) {
         auto msg = fmt::format("Error parsing onion request: {}",

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -527,6 +527,7 @@ void connection_t::process_onion_req_v2() {
 
         if (auto it = json_req.find("enc_type"); it != json_req.end())
             data.enc_type = parse_enc_type(it->get_ref<const std::string&>());
+        // Otherwise stay at default aes-gcm
 
         // Allows a fake starting hop number (to make it harder for intermediate hops to know where
         // they are).  If omitted, defaults to 0.

--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -4,6 +4,7 @@
 #include "oxen_common.h"
 #include "oxen_logger.h"
 #include "oxend_key.h"
+#include "channel_encryption.hpp"
 #include "oxenmq/connections.h"
 #include "oxenmq/oxenmq.h"
 #include "request_handler.h"
@@ -105,11 +106,12 @@ void OxenmqServer::handle_ping(oxenmq::Message& message) {
     message.send_reply("pong");
 }
 
-void OxenmqServer::handle_onion_request(oxenmq::Message& message) {
+void OxenmqServer::handle_onion_request(
+        std::string_view payload,
+        OnionRequestMetadata&& data,
+        oxenmq::Message::DeferredSend send) {
 
-    OXEN_LOG(debug, "Got an onion request over OxenMQ");
-
-    auto on_response = [send=message.send_later()](oxen::Response res) {
+    data.cb = [send](oxen::Response res) {
         if (OXEN_LOG_ENABLED(trace))
             OXEN_LOG(trace, "on response: {}...", to_string(res).substr(0, 100));
 
@@ -118,21 +120,54 @@ void OxenmqServer::handle_onion_request(oxenmq::Message& message) {
                 std::move(res).message());
     };
 
+    if (data.hop_no > MAX_ONION_HOPS)
+        return data.cb({Status::BAD_REQUEST, "onion request max path length exceeded"});
+
+    request_handler_->process_onion_req(payload, std::move(data));
+}
+
+void OxenmqServer::handle_onion_request(oxenmq::Message& message) {
+    std::pair<std::string_view, OnionRequestMetadata> data;
+    try {
+        if (message.data.size() != 1)
+            throw std::runtime_error{"expected 1 part, got " + std::to_string(message.data.size())};
+
+        data = decode_onion_data(message.data[0]);
+    } catch (const std::exception& e) {
+        auto msg = "Invalid internal onion request: "s + e.what();
+        OXEN_LOG(error, "{}", msg);
+        message.send_reply(
+                std::to_string(static_cast<int>(Status::BAD_REQUEST)), msg);
+        return;
+    }
+
+    handle_onion_request(data.first, std::move(data.second), message.send_later());
+}
+
+void OxenmqServer::handle_onion_req_v2(oxenmq::Message& message) {
+
+    OXEN_LOG(debug, "Got a v2 onion request over OxenMQ");
+
+    const int bad_code = static_cast<int>(Status::BAD_REQUEST);
     if (message.data.size() != 2) {
         OXEN_LOG(error, "Expected 2 message parts, got {}",
                  message.data.size());
-        return on_response({Status::BAD_REQUEST, "Incorrect number of request parts"});
+        message.send_reply(std::to_string(bad_code),
+                "Incorrect number of onion request message parts");
+        return;
     }
 
     auto eph_key = extract_x25519_from_hex(message.data[0]);
     if (!eph_key) {
         OXEN_LOG(error, "no ephemeral key in omq onion request");
-        return on_response({Status::BAD_REQUEST, "Missing ephemeral key"});
+        message.send_reply(std::to_string(bad_code), "Missing ephemeral key");
+        return;
     }
-    const auto& ciphertext = message.data[1];
 
-    request_handler_->process_onion_req(
-            std::string{ciphertext}, *eph_key, on_response);
+    handle_onion_request(
+            message.data[1], // ciphertext
+            {*eph_key, nullptr, 1 /* hopno */, EncryptType::aes_gcm},
+            message.send_later());
 }
 
 void OxenmqServer::handle_get_logs(oxenmq::Message& message) {
@@ -218,7 +253,9 @@ OxenmqServer::OxenmqServer(
                     std::to_string(static_cast<int>(Status::BAD_REQUEST)),
                     "onion requests v1 not supported");
         })
-        .add_request_command("onion_req_v2", [this](auto& m) { handle_onion_request(m); })
+        // TODO: Backwards compat, only used up until HF18
+        .add_request_command("onion_req_v2", [this](auto& m) { handle_onion_req_v2(m); })
+        .add_request_command("onion_request", [this](auto& m) { handle_onion_request(m); })
         ;
 
     omq_.add_category("service", oxenmq::AuthLevel::admin)
@@ -266,6 +303,41 @@ void OxenmqServer::init(ServiceNode* sn, RequestHandler* rh, oxenmq::address oxe
     request_handler_ = rh;
     omq_.start();
     connect_oxend(oxend_rpc);
+}
+
+std::string OxenmqServer::encode_onion_data(std::string_view payload, const OnionRequestMetadata& data) {
+    return oxenmq::bt_serialize<oxenmq::bt_dict>({
+            {"d", payload},
+            {"ek", data.ephem_key.view()},
+            {"et", to_string(data.enc_type)},
+            {"nh", data.hop_no},
+    });
+}
+
+std::pair<std::string_view, OnionRequestMetadata> OxenmqServer::decode_onion_data(std::string_view data) {
+    // NB: stream parsing here is alphabetical
+    std::pair<std::string_view, OnionRequestMetadata> result;
+    auto& [payload, meta] = result;
+    oxenmq::bt_dict_consumer d{data};
+    if (!d.skip_until("d"))
+        throw std::runtime_error{"required data payload not found"};
+    payload = d.consume_string_view();
+
+    if (!d.skip_until("ek"))
+        throw std::runtime_error{"ephemeral key not found"};
+    meta.ephem_key = x25519_pubkey::from_bytes(d.consume_string_view());
+
+    if (d.skip_until("et"))
+        meta.enc_type = parse_enc_type(d.consume_string_view());
+    else
+        meta.enc_type = EncryptType::aes_gcm;
+
+    if (d.skip_until("nh"))
+        meta.hop_no = d.consume_integer<int>();
+    if (meta.hop_no < 1)
+        meta.hop_no = 1;
+
+    return result;
 }
 
 } // namespace oxen

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -38,8 +38,8 @@ class OxenmqServer {
     // Handle Session client requests arrived via proxy
     void handle_sn_proxy_exit(oxenmq::Message& message);
 
-    // v2 indicates whether to use the new (v2) protocol
-    void handle_onion_request(oxenmq::Message& message, bool v2);
+    // Called for the sn.onion_req_v2 endpoint
+    void handle_onion_request(oxenmq::Message& message);
 
     // sn.ping - sent by SNs to ping each other.
     void handle_ping(oxenmq::Message& message);

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -15,6 +15,7 @@ namespace oxen {
 struct oxend_key_pair_t;
 class ServiceNode;
 class RequestHandler;
+struct OnionRequestMetadata;
 
 void omq_logger(oxenmq::LogLevel level, const char* file, int line,
         std::string message);
@@ -39,7 +40,16 @@ class OxenmqServer {
     void handle_sn_proxy_exit(oxenmq::Message& message);
 
     // Called for the sn.onion_req_v2 endpoint
+    void handle_onion_req_v2(oxenmq::Message& message);
+
+    // Called starting at HF18 for SS-to-SS onion requests
     void handle_onion_request(oxenmq::Message& message);
+
+    // Handles a decoded onion request
+    void handle_onion_request(
+            std::string_view payload,
+            OnionRequestMetadata&& data,
+            oxenmq::Message::DeferredSend send);
 
     // sn.ping - sent by SNs to ping each other.
     void handle_ping(oxenmq::Message& message);
@@ -84,6 +94,12 @@ class OxenmqServer {
         assert(oxend_conn_);
         omq_.send(oxend_conn(), std::forward<Args>(args)...);
     }
+
+    // Encodes the onion request data that we send for internal SN-to-SN onion requests starting at
+    // HF18.
+    static std::string encode_onion_data(std::string_view payload, const OnionRequestMetadata& data);
+    // Decodes onion request data; throws if invalid formatted or missing required fields.
+    static std::pair<std::string_view, OnionRequestMetadata> decode_onion_data(std::string_view data);
 };
 
 } // namespace oxen

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) {
         OXEN_LOG(info, "- x25519:  {}", me.pubkey_x25519);
         OXEN_LOG(info, "- lokinet: {}", me.pubkey_ed25519.snode_address());
 
-        ChannelEncryption channel_encryption{private_key_x25519};
+        ChannelEncryption channel_encryption{private_key_x25519, me.pubkey_x25519};
 
         // Set up oxenmq now, but don't actually start it until after we set up the ServiceNode
         // instance (because ServiceNode and OxenmqServer reference each other).

--- a/httpserver/onion_processing.cpp
+++ b/httpserver/onion_processing.cpp
@@ -141,9 +141,7 @@ void RequestHandler::process_onion_req(std::string_view ciphertext,
         return data.cb({Status::SERVICE_UNAVAILABLE, std::move(msg)});
     }
 
-    OXEN_LOG(critical, "process_onion_req, ciphertext is {} bytes, my key is {}, ephem key is {}",
-            ciphertext.size(), service_node_.own_address().pubkey_x25519, data.ephem_key
-            );
+    OXEN_LOG(debug, "process_onion_req");
 
     var::visit([&](auto&& x) { process_onion_req(std::move(x), std::move(data)); },
             process_ciphertext_v2(channel_cipher_, ciphertext, data.ephem_key, data.enc_type));

--- a/httpserver/onion_processing.h
+++ b/httpserver/onion_processing.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <variant>
 #include "oxend_key.h"
+#include "channel_encryption.hpp"
 
 namespace oxen {
 
@@ -20,6 +21,8 @@ struct RelayToNodeInfo {
     std::string ciphertext;
     // Key to be forwarded to next node for decryption
     x25519_pubkey ephemeral_key;
+    // The encryption type with which this request was encoded
+    EncryptType enc_type;
     // Next node's ed25519 key
     ed25519_pubkey next_node;
 };

--- a/httpserver/onion_processing.h
+++ b/httpserver/onion_processing.h
@@ -7,6 +7,11 @@
 
 namespace oxen {
 
+// Maximum onion request hops we'll accept before we return an error; this is deliberately larger
+// than we actually use so that the client can choose to obscure hop positioning by starting at
+// somewhere higher than 0.
+inline constexpr int MAX_ONION_HOPS = 15;
+
 using CiphertextPlusJson = std::pair<std::string, nlohmann::json>;
 
 /// The request is to be forwarded to another SS node
@@ -14,7 +19,7 @@ struct RelayToNodeInfo {
     /// Inner ciphertext for next node
     std::string ciphertext;
     // Key to be forwarded to next node for decryption
-    std::string ephemeral_key;
+    x25519_pubkey ephemeral_key;
     // Next node's ed25519 key
     ed25519_pubkey next_node;
 };

--- a/httpserver/request_handler.cpp
+++ b/httpserver/request_handler.cpp
@@ -349,7 +349,7 @@ Response RequestHandler::process_retrieve(const json& params) {
 }
 
 void RequestHandler::process_client_req(
-    const std::string& req_json, std::function<void(oxen::Response)> cb) {
+    std::string_view req_json, std::function<void(oxen::Response)> cb) {
 
     OXEN_LOG(trace, "process_client_req str <{}>", req_json);
 
@@ -469,7 +469,7 @@ void RequestHandler::process_lns_request(
 }
 
 void RequestHandler::process_onion_exit(
-    const x25519_pubkey& eph_key, const std::string& body,
+    std::string_view body,
     std::function<void(oxen::Response)> cb) {
 
     OXEN_LOG(debug, "Processing onion exit!");

--- a/httpserver/request_handler.h
+++ b/httpserver/request_handler.h
@@ -151,8 +151,7 @@ class RequestHandler {
     // The result will arrive asynchronously, so it needs a callback handler
     void process_onion_req(std::string_view ciphertext,
                            const x25519_pubkey& ephem_key,
-                           std::function<void(oxen::Response)> cb,
-                           // Whether to use the new v2 protocol
-                           bool v2 = false);
+                           std::function<void(oxen::Response)> cb);
+
 };
 } // namespace oxen

--- a/httpserver/request_handler.h
+++ b/httpserver/request_handler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "onion_processing.h"
 #include "oxen_common.h"
 #include "oxend_key.h"
 #include <string>
@@ -153,5 +154,13 @@ class RequestHandler {
                            const x25519_pubkey& ephem_key,
                            std::function<void(oxen::Response)> cb);
 
+    void process_onion_req(FinalDestinationInfo&& res,
+            const x25519_pubkey& ekey, std::function<void(oxen::Response)> cb);
+    void process_onion_req(RelayToNodeInfo&& res,
+            const x25519_pubkey& ekey, std::function<void(oxen::Response)> cb);
+    void process_onion_req(RelayToServerInfo&& res,
+            const x25519_pubkey& ekey, std::function<void(oxen::Response)> cb);
+    void process_onion_req(ProcessCiphertextError&& res,
+            const x25519_pubkey& ekey, std::function<void(oxen::Response)> cb);
 };
 } // namespace oxen

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -295,8 +295,8 @@ void ServiceNode::send_onion_to_sn(const sn_record_t& sn,
             sn.pubkey_x25519.view(), "sn.onion_req_v2", std::move(cb),
             oxenmq::send_option::request_timeout{30s}, data.ephem_key.hex(), payload);
     } else {
-        // Use the newer (v3, I suppose, though it's internal) where when bencode everything (which
-        // is a bit more compact than sending the eph_key in hex, plus allows other metadata such as
+        // Use the newer (v3, I suppose, though it's internal) where we bencode everything (which is
+        // a bit more compact than sending the eph_key in hex, plus allows other metadata such as
         // the hop number and the encryption type).
         data.hop_no++;
         lmq_server_->request(

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -31,6 +31,8 @@ inline constexpr int STORAGE_SERVER_HARDFORK = 17;
 inline constexpr int HARDFORK_SN_PING = 18;
 // HF at which we can stop using hex conversion for pubkey sorting for testee/testers.
 inline constexpr int HARDFORK_NO_HEX_SORT_HACK = 18;
+// HF at which we start using the sn.onion_request endpoint instead of sn.onion_req_v2
+inline constexpr int HARDFORK_OMQ_ONION_REQ_BENCODE = 18;
 
 namespace storage {
 struct Item;
@@ -39,6 +41,8 @@ struct Item;
 struct sn_response_t;
 
 class OxenmqServer;
+
+struct OnionRequestMetadata;
 
 namespace ss_client {
 class Request;
@@ -196,16 +200,10 @@ class ServiceNode {
     void record_proxy_request();
     void record_onion_request();
 
-    // This is new, so it does not need to support http, thus new (if temp)
-    // method
-    void send_onion_to_sn_v1(const sn_record_t& sn, const std::string& payload,
-                             const std::string& eph_key,
-                             ss_client::Callback cb) const;
-
-    /// Same as v1, but using the new protocol (ciphertext as binary)
-    void send_onion_to_sn_v2(const sn_record_t& sn, const std::string& payload,
-                             const std::string& eph_key,
-                             ss_client::Callback cb) const;
+    /// Sends an onion request to the next SS
+    void send_onion_to_sn(const sn_record_t& sn, std::string_view payload,
+                          OnionRequestMetadata&& data,
+                          ss_client::Callback cb) const;
 
     // TODO: move this eventually out of SN
     // Send by either http or omq

--- a/unit_test/encrypt.cpp
+++ b/unit_test/encrypt.cpp
@@ -17,8 +17,8 @@ const auto bob_pubkey = oxen::x25519_pubkey::from_hex("f7b99da2e25e3c399902641c7
 const auto bob_seckey = oxen::x25519_seckey::from_hex("f512f68e81a932aa2ff6d8723baa260a43a6f789d61c91b71f73e4f284e3600a");
 
 BOOST_AUTO_TEST_CASE(cbc) {
-    ChannelEncryption alice_box{alice_seckey};
-    ChannelEncryption bob_box{bob_seckey};
+    ChannelEncryption alice_box{alice_seckey, alice_pubkey};
+    ChannelEncryption bob_box{bob_seckey, bob_pubkey};
 
     auto ctext_bob = alice_box.encrypt_cbc(plaintext_data, bob_pubkey);
     BOOST_CHECK_EQUAL(ctext_bob.size(), plaintext_data.size() + 29);
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE(cbc) {
 }
 
 BOOST_AUTO_TEST_CASE(gcm) {
-    ChannelEncryption alice_box{alice_seckey};
-    ChannelEncryption bob_box{bob_seckey};
+    ChannelEncryption alice_box{alice_seckey, alice_pubkey};
+    ChannelEncryption bob_box{bob_seckey, bob_pubkey};
 
     auto ctext_bob = alice_box.encrypt_gcm(plaintext_data, bob_pubkey);
     BOOST_CHECK_EQUAL(ctext_bob.size(), plaintext_data.size() + 28);
@@ -46,6 +46,23 @@ BOOST_AUTO_TEST_CASE(gcm) {
     auto ctext_alice = bob_box.encrypt_gcm(plaintext_data, alice_pubkey);
     BOOST_CHECK_EQUAL(ctext_alice.size(), plaintext_data.size() + 28);
     auto ptext_alice = alice_box.decrypt_gcm(ctext_alice, bob_pubkey);
+
+    BOOST_CHECK_EQUAL(ptext_alice, plaintext_data);
+}
+
+BOOST_AUTO_TEST_CASE(xchacha20) {
+    ChannelEncryption alice_box{alice_seckey, alice_pubkey};
+    ChannelEncryption bob_box{bob_seckey, bob_pubkey};
+
+    auto ctext_bob = alice_box.encrypt_xchacha20(plaintext_data, bob_pubkey);
+    BOOST_CHECK_EQUAL(ctext_bob.size(), plaintext_data.size() + 40);
+    auto ptext_bob = bob_box.decrypt_xchacha20(ctext_bob, alice_pubkey);
+
+    BOOST_CHECK_EQUAL(ptext_bob, plaintext_data);
+
+    auto ctext_alice = bob_box.encrypt_xchacha20(plaintext_data, alice_pubkey);
+    BOOST_CHECK_EQUAL(ctext_alice.size(), plaintext_data.size() + 40);
+    auto ptext_alice = alice_box.decrypt_xchacha20(ctext_alice, bob_pubkey);
 
     BOOST_CHECK_EQUAL(ptext_alice, plaintext_data);
 }

--- a/unit_test/encrypt.cpp
+++ b/unit_test/encrypt.cpp
@@ -51,20 +51,51 @@ BOOST_AUTO_TEST_CASE(gcm) {
 }
 
 BOOST_AUTO_TEST_CASE(xchacha20) {
-    ChannelEncryption alice_box{alice_seckey, alice_pubkey};
-    ChannelEncryption bob_box{bob_seckey, bob_pubkey};
+    ChannelEncryption alice_server{alice_seckey, alice_pubkey};
+    ChannelEncryption alice_client{alice_seckey, alice_pubkey, false};
+    ChannelEncryption bob_server{bob_seckey, bob_pubkey};
+    ChannelEncryption bob_client{bob_seckey, bob_pubkey, false};
 
-    auto ctext_bob = alice_box.encrypt_xchacha20(plaintext_data, bob_pubkey);
+    auto ctext_bob = alice_client.encrypt_xchacha20(plaintext_data, bob_pubkey);
     BOOST_CHECK_EQUAL(ctext_bob.size(), plaintext_data.size() + 40);
-    auto ptext_bob = bob_box.decrypt_xchacha20(ctext_bob, alice_pubkey);
+    auto ptext_bob = bob_server.decrypt_xchacha20(ctext_bob, alice_pubkey);
 
     BOOST_CHECK_EQUAL(ptext_bob, plaintext_data);
 
-    auto ctext_alice = bob_box.encrypt_xchacha20(plaintext_data, alice_pubkey);
+    BOOST_CHECK_THROW(
+            bob_client.decrypt_xchacha20(ctext_bob, alice_pubkey),
+            std::runtime_error);
+
+    auto ctext_alice = bob_client.encrypt_xchacha20(plaintext_data, alice_pubkey);
     BOOST_CHECK_EQUAL(ctext_alice.size(), plaintext_data.size() + 40);
-    auto ptext_alice = alice_box.decrypt_xchacha20(ctext_alice, bob_pubkey);
+    auto ptext_alice = alice_server.decrypt_xchacha20(ctext_alice, bob_pubkey);
 
     BOOST_CHECK_EQUAL(ptext_alice, plaintext_data);
+
+    BOOST_CHECK_THROW(
+            alice_client.decrypt_xchacha20(ctext_alice, bob_pubkey),
+            std::runtime_error);
+
+    ctext_bob = alice_server.encrypt_xchacha20(plaintext_data, bob_pubkey);
+    BOOST_CHECK_EQUAL(ctext_bob.size(), plaintext_data.size() + 40);
+    ptext_bob = bob_client.decrypt_xchacha20(ctext_bob, alice_pubkey);
+
+    BOOST_CHECK_EQUAL(ptext_bob, plaintext_data);
+
+    BOOST_CHECK_THROW(
+            bob_server.decrypt_xchacha20(ctext_bob, alice_pubkey),
+            std::runtime_error);
+
+    ctext_alice = bob_server.encrypt_xchacha20(plaintext_data, alice_pubkey);
+    BOOST_CHECK_EQUAL(ctext_alice.size(), plaintext_data.size() + 40);
+    ptext_alice = alice_client.decrypt_xchacha20(ctext_alice, bob_pubkey);
+
+    BOOST_CHECK_EQUAL(ptext_alice, plaintext_data);
+
+    BOOST_CHECK_THROW(
+            alice_server.decrypt_xchacha20(ctext_alice, bob_pubkey),
+            std::runtime_error);
+
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_test/onion_requests.cpp
+++ b/unit_test/onion_requests.cpp
@@ -90,14 +90,14 @@ BOOST_AUTO_TEST_CASE(relay_to_node) {
 
     auto data = prefix + R"#({
         "destination": "ffffeeeeddddccccbbbbaaaa9999888877776666555544443333222211110000",
-        "ephemeral_key": "ephemeral_key"
+        "ephemeral_key": "0000111122223333444455556666777788889999000011112222333344445555"
     })#";
 
     auto res = process_inner_request(data);
 
     auto expected = RelayToNodeInfo {
         ciphertext,
-        "ephemeral_key",
+        x25519_pubkey::from_hex("0000111122223333444455556666777788889999000011112222333344445555"),
         EncryptType::aes_gcm,
         ed25519_pubkey::from_hex("ffffeeeeddddccccbbbbaaaa9999888877776666555544443333222211110000")
     };

--- a/unit_test/onion_requests.cpp
+++ b/unit_test/onion_requests.cpp
@@ -98,6 +98,7 @@ BOOST_AUTO_TEST_CASE(relay_to_node) {
     auto expected = RelayToNodeInfo {
         ciphertext,
         "ephemeral_key",
+        EncryptType::aes_gcm,
         ed25519_pubkey::from_hex("ffffeeeeddddccccbbbbaaaa9999888877776666555544443333222211110000")
     };
 


### PR DESCRIPTION
Redoes the SS-to-SS OMQ protocol to use a bencoded dict as data.

This allows passing other metadata parameters such as the hop number and encryption type, and allows future protocol extensions without needing a new endpoint.

Also adds a max hop length of 15, and allows the client to start somewhere other than 0 by adding `"hop_no": N` into the initial onion request.

Finally, this adds xchacha20-poly1305 encryption by passing `"enc_type": "xchacha20"` in the onion request metadata.  (Note that this uses a more secure shared key format of `H(aB || A || B)` rather than just `aB` so needs some client-side changes to start using).

This is all backwards compatible:
- up until HF18, sn.onion_req_v2 is still used (which is always gcm, and doesn't have hop limits)
- clients making onion requests do not have to change anything until they want to opt in to hop and encryption type changes; the defaults are designed to use the existing onion encryption without any modifications.